### PR TITLE
fix: resolve zizmor findings and update tooling configs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@ on:
     - cron: "22 8 * * 0"
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -18,17 +22,17 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      packages: read
-      security-events: write
+      actions: read # to read Actions run and workflow metadata
+      contents: read # to check out the repository
+      packages: read # to read packages
+      security-events: write # to upload SARIF results to code scanning
     strategy:
       fail-fast: false
       matrix:
         language: ["actions", "javascript"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/codeql-analysis@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -22,16 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
-      issues: write
-      packages: read
-      pull-requests: write
-      statuses: write
+      contents: read # to check out the repository
+      issues: write # to comment on and label issues
+      packages: read # to read packages
+      pull-requests: write # to comment on and label pull requests
+      statuses: write # to update commit statuses
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install and enable corepack
@@ -48,7 +49,7 @@ jobs:
 
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/pr-lint@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 env:
@@ -17,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      statuses: write
-      contents: read
-      packages: read
-      issues: write
-      pull-requests: write
+      statuses: write # to update commit statuses
+      contents: read # to check out the repository
+      packages: read # to read packages
+      issues: write # to comment on and label issues
+      pull-requests: write # to comment on and label pull requests
 
     steps:
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/pr-lint@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04
 
   publish:
     name: Publish
@@ -43,6 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node.js Environment

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -17,7 +21,7 @@ jobs:
 
     permissions:
       contents: write # only for delete-branch option
-      issues: write
-      pull-requests: write
+      issues: write # to comment on and label issues
+      pull-requests: write # to comment on and label pull requests
     steps:
-      - uses: ivuorinen/actions/stale@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+      - uses: ivuorinen/actions/stale@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -29,13 +29,14 @@ jobs:
     timeout-minutes: 10
 
     permissions:
-      contents: read
-      issues: write
+      contents: read # to check out the repository
+      issues: write # to comment on and label issues
 
     steps:
       - name: ⤵️ Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: ⤵️ Sync Latest Labels Definitions
-        uses: ivuorinen/actions/sync-labels@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/sync-labels@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+---
+# zizmor configuration: https://docs.zizmor.sh/configuration/
+rules:
+  adhoc-packages:
+    # corepack must be bootstrapped globally; no lockfile applies
+    ignore:
+      - pr-lint.yml
+      - publish.yml
+  use-trusted-publishing:
+    # npm trusted publishing requires registry-side setup; tracked separately
+    ignore:
+      - publish.yml

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -3,6 +3,13 @@
 # See all available variables at
 # https://megalinter.io/configuration/ and in linters documentation
 
+# Ensure zizmor runs authenticated: MegaLinter unsets GITHUB_TOKEN for linters
+# unless listed here, which left zizmor unauthenticated and failing
+# impostor-commit with HTTP 401.
+# https://megalinter.io/latest/descriptors/action_zizmor/
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN
+
 APPLY_FIXES: all
 SHOW_ELAPSED_TIME: false # Show elapsed time at the end of MegaLinter run
 PARALLEL: true


### PR DESCRIPTION
## Summary

- Resolve all `zizmor -p` (pedantic) findings in GitHub Actions workflows:
  - add workflow-level concurrency limits
  - document job permissions with explanatory comments
  - set `persist-credentials: false` on checkouts that do not push
  - replace `read-all` workflow permissions with explicit empty defaults
  - add `.github/zizmor.yml` with documented, justified ignores (corepack bootstrap, npm trusted publishing pending registry-side setup)
- Allow `GITHUB_TOKEN` for zizmor in MegaLinter (`ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES`)
- Bump pinned action versions

## Verification

- `zizmor -p .github/workflows`: no findings
- `prek run --from-ref main --to-ref HEAD`: all hooks pass